### PR TITLE
Add dry-run mode to VLLMD Hypervisor systemd installer

### DIFF
--- a/vllmd-hypervisor/NEXT.md
+++ b/vllmd-hypervisor/NEXT.md
@@ -1,0 +1,86 @@
+# VLLMD Hypervisor Next Steps
+
+This document outlines the planned next steps for the VLLMD Hypervisor project, focusing on enhancing configuration management and validation.
+
+## Upcoming Features
+
+### 1. Dry Run Mode
+
+Add a dry-run flag to the installer script that shows what would be done without making any changes:
+
+- Show which files would be created
+- Display systemd services that would be enabled
+- Output environment file contents
+- No actual filesystem or systemd changes
+
+**Issue**: #TBD - "Add dry-run mode to VLLMD Hypervisor systemd installer"
+
+### 2. Configuration Schema Definition
+
+Create a JSON Schema definition for the TOML configuration file:
+
+- Define all valid configuration options
+- Document field purposes and constraints
+- Specify required vs. optional fields
+- Provide type definitions and validation rules
+
+**Issue**: #TBD - "Add configuration schema definition for VLLMD Hypervisor"
+
+### 3. Schema Validation
+
+Implement schema validation for the configuration file:
+
+- Validate configuration against the schema definition
+- Provide helpful error messages for invalid configurations
+- Support strict and lenient validation modes
+- Add schema version tracking
+
+**Issue**: #TBD - "Implement schema validation for VLLMD Hypervisor configuration"
+
+## Implementation Plan
+
+Each feature will be implemented independently with its own:
+- GitHub issue for tracking
+- Feature branch for development
+- Pull request for review
+- Documentation updates
+
+<!--
+INSTRUCTIONS:
+
+This is an iterative development process with the following steps for each feature:
+
+1. ISSUE CREATION:
+- Create a detailed GitHub issue for the feature
+- Include motivation, requirements, and acceptance criteria
+- Add relevant labels and assign to the sprint
+
+2. BRANCH CREATION:
+- Create a topic branch named: vllmd-hypervisor/<feature-name>
+- Base it on the latest main branch
+
+3. IMPLEMENTATION:
+- Develop the feature according to the requirements
+- Add tests to verify functionality
+- Update documentation to reflect changes
+- Follow existing coding patterns and style
+
+4. PULL REQUEST:
+- Create a pull request with a detailed description
+- Reference the issue number with "Resolves #XX"
+- Include testing evidence and implementation notes
+- Request review from the team
+
+5. REVIEW AND MERGE:
+- Address review feedback
+- Update the PR as needed
+- Merge using rebase strategy (not merge commits)
+- Delete the branch after successful merge
+
+The features should be implemented in this order:
+1. Dry Run Mode
+2. Configuration Schema Definition
+3. Schema Validation
+
+Each feature builds upon the previous one but should be implemented with minimal dependencies to allow independent review and merging.
+-->

--- a/vllmd-hypervisor/NEXT.md
+++ b/vllmd-hypervisor/NEXT.md
@@ -1,10 +1,10 @@
-# VLLMD Hypervisor Next Steps
+# VLLMD Hypervisor Immediate Tactical Tasks
 
-This document outlines the planned next steps for the VLLMD Hypervisor project, focusing on enhancing configuration management and validation.
+This document outlines the immediate tactical tasks for the VLLMD Hypervisor project to improve configuration reliability and user experience.
 
-## Upcoming Features
+## Next Implementation Tasks
 
-### 1. Dry Run Mode
+### 1. Implement Dry Run Mode
 
 Add a dry-run flag to the installer script that shows what would be done without making any changes:
 
@@ -13,9 +13,12 @@ Add a dry-run flag to the installer script that shows what would be done without
 - Output environment file contents
 - No actual filesystem or systemd changes
 
-**Issue**: #TBD - "Add dry-run mode to VLLMD Hypervisor systemd installer"
+**Issue**: #TBD - "Add dry-run mode to VLLMD Hypervisor systemd installer"  
+**Priority**: High  
+**Complexity**: Low  
+**Estimated effort**: 1-2 days
 
-### 2. Configuration Schema Definition
+### 2. Create Configuration Schema Definition
 
 Create a JSON Schema definition for the TOML configuration file:
 
@@ -24,9 +27,12 @@ Create a JSON Schema definition for the TOML configuration file:
 - Specify required vs. optional fields
 - Provide type definitions and validation rules
 
-**Issue**: #TBD - "Add configuration schema definition for VLLMD Hypervisor"
+**Issue**: #TBD - "Add configuration schema definition for VLLMD Hypervisor"  
+**Priority**: Medium  
+**Complexity**: Medium  
+**Estimated effort**: 2-3 days
 
-### 3. Schema Validation
+### 3. Implement Schema Validation
 
 Implement schema validation for the configuration file:
 
@@ -35,17 +41,20 @@ Implement schema validation for the configuration file:
 - Support strict and lenient validation modes
 - Add schema version tracking
 
-**Issue**: #TBD - "Implement schema validation for VLLMD Hypervisor configuration"
+**Issue**: #TBD - "Implement schema validation for VLLMD Hypervisor configuration"  
+**Priority**: Medium  
+**Complexity**: Medium  
+**Estimated effort**: 2-3 days
 
-## Implementation Plan
+## Task Execution Approach
 
-Each feature will be implemented independently with its own:
+Each task will be implemented independently with its own:
 - GitHub issue for tracking
 - Feature branch for development
 - Pull request for review
 - Documentation updates
 
-<!--
+<\!--
 INSTRUCTIONS:
 
 This is an iterative development process with the following steps for each feature:

--- a/vllmd-hypervisor/generate-init-vllmd-hypervisor.sh
+++ b/vllmd-hypervisor/generate-init-vllmd-hypervisor.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# generate-init-vllmd-hypervisor.sh - Create a cloud-init configuration disk for VLLMD VMs
+#
+# This script generates a FAT filesystem image containing cloud-init configuration
+# for VM provisioning. The image includes user-data and meta-data files that
+# configure the VM's hostname and user accounts.
+#
+# Usage:
+#   ./generate-cloudinit-disk.sh [OPTIONS] [vm_name]
+#
+# Options:
+#   --dry-run     Show what would be done without making any changes
+#
+# Arguments:
+#   vm_name - Optional VM name (defaults to "vllmd-vm")
+#
+# Examples:
+#   ./generate-cloudinit-disk.sh
+#   ./generate-cloudinit-disk.sh my-custom-vm
+#   ./generate-cloudinit-disk.sh --dry-run
+#
+
+set -euo pipefail
+
+# Process command line arguments
+DRY_RUN=0
+VM_NAME="vllmd-vm"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        *)
+            VM_NAME="$1"
+            shift
+            ;;
+    esac
+done
+
+OUTPUT_PATH="/mnt/aw/cloudinit-boot-disk.raw"
+
+# Create temporary directory for cloud-init files
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf ${TEMP_DIR}' EXIT
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "[DRY RUN] Would generate cloud-init configuration for ${VM_NAME}"
+    echo "[DRY RUN] Would create meta-data file with:"
+    echo "  instance-id: ${VM_NAME}"
+    echo "  local-hostname: ${VM_NAME}"
+    
+    echo "[DRY RUN] Would create user-data file with:"
+    echo "  - User: sdake"
+    echo "  - SSH import from GitHub: gh:sdake"
+    echo "  - Sudo access: ALL=(ALL) NOPASSWD:ALL"
+    echo "  - Shell: /bin/bash"
+    echo "  - Password authentication: enabled"
+    
+    echo "[DRY RUN] Would create directory: $(dirname "${OUTPUT_PATH}")"
+    echo "[DRY RUN] Would create FAT filesystem image at: ${OUTPUT_PATH}"
+    echo "[DRY RUN] Would copy user-data and meta-data files to the image"
+    
+    echo "[DRY RUN] Script would complete without making any changes"
+    exit 0
+fi
+
+echo "Generating cloud-init configuration for ${VM_NAME}..."
+
+# Create meta-data file
+cat > "${TEMP_DIR}/meta-data" << EOF
+#cloud-config
+---
+instance-id: ${VM_NAME}
+local-hostname: ${VM_NAME}
+EOF
+
+# Create user-data file
+cat > "${TEMP_DIR}/user-data" << EOF
+#cloud-config
+---
+users:
+  - name: sdake
+    ssh_import_id:
+      - gh:sdake
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: false
+    inactive: false
+    shell: /bin/bash
+ssh_pwauth: true
+EOF
+
+echo "Creating cloud-init disk image at ${OUTPUT_PATH}..."
+
+# Ensure parent directory exists
+mkdir -p $(dirname "${OUTPUT_PATH}")
+
+# Create FAT filesystem image
+/usr/sbin/mkdosfs -n CIDATA -C "${OUTPUT_PATH}" 8192
+
+# Copy files to the image
+mcopy -oi "${OUTPUT_PATH}" -s "${TEMP_DIR}/user-data" ::
+mcopy -oi "${OUTPUT_PATH}" -s "${TEMP_DIR}/meta-data" ::
+
+echo "Cloud-init configuration disk created successfully at ${OUTPUT_PATH}"
+echo "This disk will be used as a secondary boot disk for all VMs"
+echo "You may need to run parts of this script with sudo if permission errors occur"

--- a/vllmd-hypervisor/install-vllmd-hypervisor-systemd.sh
+++ b/vllmd-hypervisor/install-vllmd-hypervisor-systemd.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# install-vllmd-hypervisor-systemd.sh
+# Configures systemd for VLLMD virtualization
+set -euo pipefail
+
+# Default configuration path
+CONFIG_PATH="$HOME/.config/vllmd/vllmd-hypervisor-runtime-defaults.toml"
+SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+# Check for TOML parser
+if ! command -v python3 &> /dev/null; then
+    echo "Error: python3 is required for TOML parsing"
+    exit 1
+fi
+
+# Function to parse TOML configuration using Python
+parse_toml() {
+    python3 - "$CONFIG_PATH" <<EOF
+import sys
+import json
+try:
+    import tomli as toml
+except ImportError:
+    try:
+        import tomllib as toml
+    except ImportError:
+        print("Error: No TOML parser found. Install with: pip install tomli")
+        sys.exit(1)
+
+try:
+    with open(sys.argv[1], "rb") as f:
+        config = toml.load(f)
+    print(json.dumps(config))
+except Exception as e:
+    print(f"Error parsing TOML: {e}", file=sys.stderr)
+    sys.exit(1)
+EOF
+}
+
+# Check if configuration file exists
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "Error: Configuration file not found: $CONFIG_PATH"
+    echo "Please create the configuration file first."
+    exit 1
+fi
+
+# Parse the TOML configuration
+CONFIG_JSON=$(parse_toml)
+
+# Create systemd user directory if it doesn't exist
+mkdir -p "$SYSTEMD_USER_DIR"
+
+# Enable systemd linger for current user
+if ! loginctl show-user "$USER" | grep -q "Linger=yes"; then
+    echo "Enabling systemd linger for user $USER"
+    sudo loginctl enable-linger "$USER"
+fi
+
+# Create systemd service templates
+cat > "$SYSTEMD_USER_DIR/vllmd-runtime-pre-start@.service" <<EOF
+[Unit]
+Description=VLLMD Pre-start setup for runtime %i
+Before=vllmd-runtime@%i.service
+Slice=vllmd.slice
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=%h/.config/vllmd/runtime-%i.env
+ExecStart=/bin/sh -c 'echo "Configuring runtime %i environment"'
+# Add pre-start commands here (network setup, etc.)
+
+[Install]
+WantedBy=default.target
+EOF
+
+cat > "$SYSTEMD_USER_DIR/vllmd-runtime@.service" <<EOF
+[Unit]
+Description=VLLMD Runtime %i
+Requires=vllmd-runtime-pre-start@%i.service
+After=vllmd-runtime-pre-start@%i.service
+Slice=vllmd.slice
+
+[Service]
+Type=simple
+EnvironmentFile=%h/.config/vllmd/runtime-%i.env
+ExecStart=/bin/sh -c 'echo "Starting VLLMD runtime %i"'
+# Add runtime start command here
+ExecStop=/bin/sh -c 'echo "Stopping VLLMD runtime %i"'
+# Add runtime stop command here
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Process runtime configurations
+echo "$CONFIG_JSON" | python3 -c '
+import sys
+import json
+import os
+
+config = json.load(sys.stdin)
+
+if "runtimes" not in config:
+    print("Error: No runtimes defined in configuration")
+    sys.exit(1)
+
+# Process each runtime
+for runtime in config["runtimes"]:
+    if "index" not in runtime or "name" not in runtime:
+        print("Warning: Skipping runtime without index or name")
+        continue
+        
+    index = runtime["index"]
+    name = runtime["name"]
+    
+    # Create environment file
+    env_path = os.path.expandvars(f"$HOME/.config/vllmd/runtime-{index}.env")
+    
+    with open(env_path, "w") as f:
+        f.write(f"# VLLMD Runtime {index} Environment\n")
+        f.write(f"VLLMD_RUNTIME_NAME={name}\n")
+        
+        # Add GPUs
+        if "gpus" in runtime and isinstance(runtime["gpus"], list):
+            gpus_str = ",".join(runtime["gpus"])
+            f.write(f"VLLMD_RUNTIME_GPUS={gpus_str}\n")
+            
+        # Add memory
+        if "memory_gb" in runtime:
+            f.write(f"VLLMD_RUNTIME_MEMORY={runtime['memory_gb']}G\n")
+            
+        # Add CPUs
+        if "cpus" in runtime:
+            f.write(f"VLLMD_RUNTIME_CPUS={runtime['cpus']}\n")
+    
+    print(f"Created environment file for runtime-{index}")
+'
+
+# Reload systemd user daemon
+systemctl --user daemon-reload
+
+# Enable services for each runtime
+echo "$CONFIG_JSON" | python3 -c '
+import sys
+import json
+import subprocess
+
+config = json.load(sys.stdin)
+
+if "runtimes" not in config:
+    print("Error: No runtimes defined in configuration")
+    sys.exit(1)
+
+# Enable services for each runtime
+for runtime in config["runtimes"]:
+    if "index" not in runtime:
+        continue
+        
+    index = runtime["index"]
+    
+    # Enable pre-start service
+    pre_start_cmd = ["systemctl", "--user", "enable", f"vllmd-runtime-pre-start@{index}.service"]
+    subprocess.run(pre_start_cmd, check=True)
+    
+    # Enable main service
+    main_cmd = ["systemctl", "--user", "enable", f"vllmd-runtime@{index}.service"]
+    subprocess.run(main_cmd, check=True)
+    
+    print(f"Enabled services for runtime-{index}")
+'
+
+echo ""
+echo "Systemd services installed and enabled."
+echo "Start a specific runtime with: systemctl --user start vllmd-runtime@<index>"
+echo "Start all runtimes with: systemctl --user start vllmd.slice"
+echo "View status with: systemctl --user status vllmd-runtime@<index>"

--- a/vllmd-hypervisor/install-vllmd-hypervisor-systemd.sh
+++ b/vllmd-hypervisor/install-vllmd-hypervisor-systemd.sh
@@ -3,9 +3,86 @@
 # Configures systemd for VLLMD virtualization
 set -euo pipefail
 
-# Default configuration path
+# Default values
+DRY_RUN=0
 CONFIG_PATH="$HOME/.config/vllmd/vllmd-hypervisor-runtime-defaults.toml"
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+# Process command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --config=*)
+            CONFIG_PATH="${1#*=}"
+            shift
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo "Install VLLMD runtime systemd services"
+            echo ""
+            echo "Options:"
+            echo "  --dry-run          Show what would be done without making changes"
+            echo "  --config=PATH      Specify a custom config file path"
+            echo "  --help             Display this help message and exit"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Output formatting for dry-run mode
+DRY_RUN_PREFIX="[DRY RUN] "
+print_dry_run() {
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo -e "${DRY_RUN_PREFIX}$1"
+    fi
+}
+
+# Safe file creation function (respects dry-run mode)
+safe_write_file() {
+    local filepath="$1"
+    local content="$2"
+    
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        print_dry_run "Would create file: $filepath"
+        print_dry_run "Content would be:"
+        print_dry_run "----------------------------------------"
+        echo "$content" | sed "s/^/${DRY_RUN_PREFIX}/"
+        print_dry_run "----------------------------------------"
+    else
+        # Create parent directory if needed
+        mkdir -p "$(dirname "$filepath")"
+        echo "$content" > "$filepath"
+        echo "Created file: $filepath"
+    fi
+}
+
+# Safe mkdir function (respects dry-run mode)
+safe_mkdir() {
+    local dirpath="$1"
+    
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        print_dry_run "Would create directory: $dirpath"
+    else
+        mkdir -p "$dirpath"
+    fi
+}
+
+# Safe command execution function (respects dry-run mode)
+safe_exec() {
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        print_dry_run "Would execute: $*"
+    else
+        "$@"
+    fi
+}
 
 # Check for TOML parser
 if ! command -v python3 &> /dev/null; then
@@ -37,6 +114,16 @@ except Exception as e:
 EOF
 }
 
+# Dry run banner
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "============================================="
+    echo "VLLMD HYPERVISOR SYSTEMD INSTALLER (DRY RUN)"
+    echo "============================================="
+    echo "This is a dry run. No changes will be made to your system."
+    echo "The following operations would be performed:"
+    echo
+fi
+
 # Check if configuration file exists
 if [ ! -f "$CONFIG_PATH" ]; then
     echo "Error: Configuration file not found: $CONFIG_PATH"
@@ -45,20 +132,33 @@ if [ ! -f "$CONFIG_PATH" ]; then
 fi
 
 # Parse the TOML configuration
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    print_dry_run "Would parse TOML configuration file: $CONFIG_PATH"
+fi
 CONFIG_JSON=$(parse_toml)
 
 # Create systemd user directory if it doesn't exist
-mkdir -p "$SYSTEMD_USER_DIR"
+safe_mkdir "$SYSTEMD_USER_DIR"
 
 # Enable systemd linger for current user
 if ! loginctl show-user "$USER" | grep -q "Linger=yes"; then
-    echo "Enabling systemd linger for user $USER"
-    sudo loginctl enable-linger "$USER"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        print_dry_run "Would enable systemd linger for user $USER"
+        print_dry_run "Would execute: sudo loginctl enable-linger $USER"
+    else
+        echo "Enabling systemd linger for user $USER"
+        sudo loginctl enable-linger "$USER"
+    fi
+else
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        print_dry_run "Systemd linger already enabled for user $USER (no changes needed)"
+    else
+        echo "Systemd linger already enabled for user $USER"
+    fi
 fi
 
-# Create systemd service templates
-cat > "$SYSTEMD_USER_DIR/vllmd-runtime-pre-start@.service" <<EOF
-[Unit]
+# Create service template content
+pre_start_service_content="[Unit]
 Description=VLLMD Pre-start setup for runtime %i
 Before=vllmd-runtime@%i.service
 Slice=vllmd.slice
@@ -67,15 +167,13 @@ Slice=vllmd.slice
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=%h/.config/vllmd/runtime-%i.env
-ExecStart=/bin/sh -c 'echo "Configuring runtime %i environment"'
+ExecStart=/bin/sh -c 'echo \"Configuring runtime %i environment\"'
 # Add pre-start commands here (network setup, etc.)
 
 [Install]
-WantedBy=default.target
-EOF
+WantedBy=default.target"
 
-cat > "$SYSTEMD_USER_DIR/vllmd-runtime@.service" <<EOF
-[Unit]
+main_service_content="[Unit]
 Description=VLLMD Runtime %i
 Requires=vllmd-runtime-pre-start@%i.service
 After=vllmd-runtime-pre-start@%i.service
@@ -84,19 +182,78 @@ Slice=vllmd.slice
 [Service]
 Type=simple
 EnvironmentFile=%h/.config/vllmd/runtime-%i.env
-ExecStart=/bin/sh -c 'echo "Starting VLLMD runtime %i"'
+ExecStart=/bin/sh -c 'echo \"Starting VLLMD runtime %i\"'
 # Add runtime start command here
-ExecStop=/bin/sh -c 'echo "Stopping VLLMD runtime %i"'
+ExecStop=/bin/sh -c 'echo \"Stopping VLLMD runtime %i\"'
 # Add runtime stop command here
 Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=default.target
-EOF
+WantedBy=default.target"
+
+# Create systemd service templates
+safe_write_file "$SYSTEMD_USER_DIR/vllmd-runtime-pre-start@.service" "$pre_start_service_content"
+safe_write_file "$SYSTEMD_USER_DIR/vllmd-runtime@.service" "$main_service_content"
 
 # Process runtime configurations
-echo "$CONFIG_JSON" | python3 -c '
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    # In dry-run mode, parse JSON and show what would be created
+    echo "$CONFIG_JSON" | python3 -c "
+import sys
+import json
+import os
+
+config = json.load(sys.stdin)
+dry_run_prefix = '[DRY RUN] '
+
+if 'runtimes' not in config:
+    print(f'{dry_run_prefix}Error: No runtimes defined in configuration')
+    sys.exit(1)
+
+print(f'{dry_run_prefix}Found {len(config['runtimes'])} runtime(s) in configuration')
+
+# Process each runtime
+for runtime in config['runtimes']:
+    if 'index' not in runtime or 'name' not in runtime:
+        print(f'{dry_run_prefix}Warning: Skipping runtime without index or name')
+        continue
+        
+    index = runtime['index']
+    name = runtime['name']
+    
+    # Show environment file that would be created
+    env_path = os.path.expandvars(f'\$HOME/.config/vllmd/runtime-{index}.env')
+    
+    print(f'{dry_run_prefix}Would create environment file: {env_path}')
+    print(f'{dry_run_prefix}Content would be:')
+    print(f'{dry_run_prefix}----------------------------------------')
+    print(f'{dry_run_prefix}# VLLMD Runtime {index} Environment')
+    print(f'{dry_run_prefix}VLLMD_RUNTIME_NAME={name}')
+    
+    # Add GPUs
+    if 'gpus' in runtime and isinstance(runtime['gpus'], list):
+        gpus_str = ','.join(runtime['gpus'])
+        print(f'{dry_run_prefix}VLLMD_RUNTIME_GPUS={gpus_str}')
+        
+    # Add memory
+    if 'memory_gb' in runtime:
+        print(f'{dry_run_prefix}VLLMD_RUNTIME_MEMORY={runtime['memory_gb']}G')
+        
+    # Add CPUs
+    if 'cpus' in runtime:
+        print(f'{dry_run_prefix}VLLMD_RUNTIME_CPUS={runtime['cpus']}')
+    
+    print(f'{dry_run_prefix}----------------------------------------')
+    
+    # Show systemd services that would be enabled
+    print(f'{dry_run_prefix}Would enable systemd services:')
+    print(f'{dry_run_prefix}  - vllmd-runtime-pre-start@{index}.service')
+    print(f'{dry_run_prefix}  - vllmd-runtime@{index}.service')
+"
+else
+    # Normal mode - actually create the files
+    echo "$CONFIG_JSON" | python3 -c '
 import sys
 import json
 import os
@@ -119,6 +276,9 @@ for runtime in config["runtimes"]:
     # Create environment file
     env_path = os.path.expandvars(f"$HOME/.config/vllmd/runtime-{index}.env")
     
+    # Ensure directory exists
+    os.makedirs(os.path.dirname(env_path), exist_ok=True)
+    
     with open(env_path, "w") as f:
         f.write(f"# VLLMD Runtime {index} Environment\n")
         f.write(f"VLLMD_RUNTIME_NAME={name}\n")
@@ -138,12 +298,24 @@ for runtime in config["runtimes"]:
     
     print(f"Created environment file for runtime-{index}")
 '
+fi
 
 # Reload systemd user daemon
-systemctl --user daemon-reload
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    print_dry_run "Would reload systemd user daemon"
+    print_dry_run "Would execute: systemctl --user daemon-reload"
+else
+    echo "Reloading systemd user daemon"
+    systemctl --user daemon-reload
+fi
 
 # Enable services for each runtime
-echo "$CONFIG_JSON" | python3 -c '
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    # In dry-run mode, we've already shown which services would be enabled
+    :
+else
+    # Normal mode - actually enable the services
+    echo "$CONFIG_JSON" | python3 -c '
 import sys
 import json
 import subprocess
@@ -171,9 +343,19 @@ for runtime in config["runtimes"]:
     
     print(f"Enabled services for runtime-{index}")
 '
+fi
 
+# Final output
 echo ""
-echo "Systemd services installed and enabled."
-echo "Start a specific runtime with: systemctl --user start vllmd-runtime@<index>"
-echo "Start all runtimes with: systemctl --user start vllmd.slice"
-echo "View status with: systemctl --user status vllmd-runtime@<index>"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "==============================================="
+    echo "DRY RUN COMPLETE - NO CHANGES WERE MADE"
+    echo "==============================================="
+    echo "To apply these changes, run the script without the --dry-run flag:"
+    echo "  bash $0"
+else
+    echo "Systemd services installed and enabled."
+    echo "Start a specific runtime with: systemctl --user start vllmd-runtime@<index>"
+    echo "Start all runtimes with: systemctl --user start vllmd.slice"
+    echo "View status with: systemctl --user status vllmd-runtime@<index>"
+fi

--- a/vllmd-hypervisor/vllmd-hypervisor-runtime-defaults.toml
+++ b/vllmd-hypervisor/vllmd-hypervisor-runtime-defaults.toml
@@ -1,0 +1,34 @@
+# VLLMD Hypervisor Runtime Defaults
+# Configuration file for VLLMD virtual machine runtime resources
+
+[global]
+# User for systemd services
+user = "sdake"
+
+# Directory paths
+state_dir = "$HOME/.local/state/vllmd-hypervisor"
+config_dir = "$HOME/.config/vllmd"
+
+# Default resource allocations
+default_memory_gb = 16
+default_cpus = 4
+
+# Runtime definitions
+[[runtimes]]
+index = 1
+gpus = ["0000:01:00.0"]
+memory_gb = 32
+cpus = 8
+name = "runtime-1"
+
+[[runtimes]]
+index = 2
+gpus = ["0000:02:00.0"]
+memory_gb = 32
+cpus = 8
+name = "runtime-2"
+
+# Network configuration
+[network]
+default_interface = "eth0"
+bridge_name = "vllmd-br0"


### PR DESCRIPTION
## Summary
Add dry-run mode to VLLMD Hypervisor systemd installer

## Details
This PR adds a dry-run mode to the systemd installer script that allows users to preview changes without making them:

- Add `--dry-run` flag to show what would be done without making changes
- Add `--config` flag to specify custom configuration file path
- Add `--help` flag for improved usability

The implementation:
- Creates helper functions for safe file operations in dry-run mode
- Shows detailed information about files that would be created
- Displays systemd services that would be enabled
- Formats dry-run output for clarity
- Maintains the same validation checks as in normal execution

## Example Usage

```bash
# Preview what changes would be made
bash install-vllmd-hypervisor-systemd.sh --dry-run

# Preview with a specific configuration file
bash install-vllmd-hypervisor-systemd.sh --dry-run --config=/path/to/config.toml
```

## Testing
The implementation has been tested with:
- Various configuration scenarios
- Both absent and present config files
- Multiple runtime definitions
- Service creation validation

The dry-run mode successfully prevents actual filesystem changes while providing clear output about what would be done.

Resolves #31

🤖 Generated with [Claude Code](https://claude.ai/code)
